### PR TITLE
Enrichit la documentation de l'installation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 public/
 node_modules/
+resources/

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Pour voir les autres projets de Compétences Pro:
 Ce site web est développé à l'aide d'[Hugo][hugo] que vous devez installer.
 
 ```
+npm install
 hugo server
 ```
 


### PR DESCRIPTION
En developpement, il faut `npm install` avant de pouvoir lancer `hugo server` pour récuperer bootstrap.

Cette PR ajoute aussi le répertoire `resources` à la liste des répertoires à ignorer.