### PR TITLE
Ajout de la page statistiques.

### DIFF
--- a/content/statistiques.html
+++ b/content/statistiques.html
@@ -1,0 +1,13 @@
+---
+title: Statistiques
+---
+
+<div class="container">
+  <div class="embed-responsive embed-responsive-16by9">
+    <iframe
+      src="http://metabase.eva.beta.gouv.fr/public/dashboard/b94d5584-421d-4b67-9365-de58f74c7a50"
+      allowtransparency
+    ></iframe>
+  </div>
+</div>
+

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -77,6 +77,7 @@
             <h1>eva</h1>
             <p>
               <a href="https://github.com/betagouv/eva" class="lien-blanc-inverse">Le code source est libre.</a><br>
+              <a href="/statistiques" class="lien-blanc-inverse">Les statistiques sont disponibles.</a><br>
               Le porteur administratif est le Haut-commissaire aux compétences et à l’inclusion par l’emploi.<br>
               L'incubateur est <a href="https://beta.gouv.fr/incubateurs/dinsic.html" class="lien-blanc-inverse">L'Incubateur de Services Numériques</a>.<br>
             </p>

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -6,4 +6,5 @@
   {{ range $block := .Params.Blocks }}
     {{ partial (printf "blocks/%s.html" $block.nom) . }}
   {{ end }}
+  {{.Content}}
 {{ end }}


### PR DESCRIPTION
Utilise la fonctionnalité d'embed de metabase. Le dasboard statistiques d'usage est utilisé.

![Screenshot_2020-03-02 Statistiques](https://user-images.githubusercontent.com/86659/75681433-dd3e0a80-5c93-11ea-8b16-c1478626f2c9.png)

contribue à betagouv/eva#793