### PR TITLE
Corrige le blocage de contenu mixé quand on essaye d'afficher les statistiques

### DIFF
--- a/content/statistiques.html
+++ b/content/statistiques.html
@@ -5,7 +5,7 @@ title: Statistiques
 <div class="container">
   <div class="embed-responsive embed-responsive-16by9">
     <iframe
-      src="http://metabase.eva.beta.gouv.fr/public/dashboard/b94d5584-421d-4b67-9365-de58f74c7a50"
+      src="https://metabase.eva.beta.gouv.fr/public/dashboard/b94d5584-421d-4b67-9365-de58f74c7a50"
       allowtransparency
     ></iframe>
   </div>


### PR DESCRIPTION
En production, si on essaye d'afficher la page de statistiques, le contenu est bloqué pour éviter d'afficher une page http alors que le site lui même est en https.

Avec ce fix, on force en https l'affichage du contenu de metabase