### PR TITLE
Site Vitrine - Ajoute un border radius à l'illustration

### DIFF
--- a/assets/sass/main.scss
+++ b/assets/sass/main.scss
@@ -108,6 +108,10 @@ $green: #9ADBD0;
   background-size: cover;
 }
 
+.illustration {
+  border-radius: 21px;
+}
+
 .pastille {
   position: relative;
   height: 150px;

--- a/layouts/partials/blocks/objectifs.html
+++ b/layouts/partials/blocks/objectifs.html
@@ -40,7 +40,7 @@
 
     <div class="row align-items-center pb-5">
       <div class="col-12 col-sm-6 col-md-8 text-center">
-        <img class="mw-100" src="/informations.jpg">
+        <img class="mw-100 illustration" src="/informations.jpg">
       </div>
       <div class="col-12 col-sm-6 col-md-4 button-infos">
         <a class="btn btn-primary btn w-100 text-left mb-2 pl-3" href="qui-sommes-nous">Qui sommes-nous ?<img class="icon-right" src="/fleche.svg"></a>


### PR DESCRIPTION
<img width="1159" alt="Capture d’écran 2020-05-11 à 17 41 48" src="https://user-images.githubusercontent.com/1309612/81581208-b811fa80-93ae-11ea-95dc-5a3d6c1444c0.png">

Fix betagouv/eva#949