### PR TITLE
Afficher l'adresse de contact dans le footer

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -82,7 +82,7 @@
               L'incubateur est <a href="https://beta.gouv.fr/incubateurs/dinsic.html" class="lien-blanc-inverse">L'Incubateur de Services Numériques</a>.<br>
             </p>
             <p>
-              <a href="mailto:{{ .Site.Params.ContactMail }}" class="lien-blanc-inverse">Contacter l’équipe</a>.
+            Contacter l’équipe : <a href="mailto:{{ .Site.Params.ContactMail }}" class="lien-blanc-inverse">{{ .Site.Params.ContactMail }}</a>
             </p>
           </div>
           <div class="d-flex align-items-center justify-content-md-end">


### PR DESCRIPTION
Pour les personnes utilisant un webmail, un défaut de configuration peut
empêcher le fonctionnement du protocol 'mailto:'.

Afficher l'email permet à ces personnes de s'en sortir en copiant
l'adresse de contact.

fix betagouv/eva#940

![Capture d’écran 2020-05-26 à 12 05 41](https://user-images.githubusercontent.com/298214/82888132-3fcc3d00-9f49-11ea-919a-b60a6a2c74a2.png)
